### PR TITLE
Make `BlockEvent.block` output a scripted subtype

### DIFF
--- a/Editor/src/custom-npcs/overrides.js
+++ b/Editor/src/custom-npcs/overrides.js
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2024 Cryville
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+
+export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
+	{
+		'type': 'CNPC_FG_NOPPES_1NPCS_1API_1EVENT_1BLOCKEVENT_3BLOCK',
+		'message0': '%{BKY_CNPC_FG_NOPPES_1NPCS_1API_1EVENT_1BLOCKEVENT_3BLOCK}',
+		'args0': [
+			{
+				'type': 'field_dropdown',
+				'name': 'output',
+				'options': [
+					['%{BKY_CNPC_T_NOPPES_1NPCS_1API_1BLOCK_1IBLOCKSCRIPTED}', 'noppes/npcs/api/block/IBlockScripted'],
+					['%{BKY_CNPC_T_NOPPES_1NPCS_1API_1BLOCK_1IBLOCKSCRIPTEDDOOR}', 'noppes/npcs/api/block/IBlockScriptedDoor'],
+				],
+			},
+		],
+		'output': ['noppes/npcs/api/block/IBlock', 'Object'],
+		'extensions': ['CNPC_VFG_NOPPES_1NPCS_1API_1EVENT_1BLOCKEVENT_3BLOCK'],
+		'colour': 30,
+	},
+]);
+
+export const msg = {
+	'CNPC_FG_NOPPES_1NPCS_1API_1EVENT_1BLOCKEVENT_3BLOCK': '(%1) event.block',
+};
+
+Blockly.Extensions.register(
+	'CNPC_VFG_NOPPES_1NPCS_1API_1EVENT_1BLOCKEVENT_3BLOCK',
+	function () {
+		var block = this;
+		function updateOutput(value) {
+			block.setOutput(true, [value, 'noppes/npcs/api/block/IBlock', 'Object']);
+		}
+		var field = this.getField('output');
+		updateOutput(field.getValue());
+		field.setValidator(function (option) { updateOutput(option); });
+	}
+);

--- a/Editor/src/index.js
+++ b/Editor/src/index.js
@@ -17,15 +17,19 @@ import { forBlock as cnpcForBlocks } from './custom-npcs/generator.g';
 import { toolbox as cnpcToolbox } from './custom-npcs/toolbox.g';
 import { msg as cnpcMsg } from './custom-npcs/msg.g';
 
+import { blocks as cnpcBlockOverrides, msg as cnpcMsgOverrides } from './custom-npcs/overrides';
+
 import './index.css';
 
 javascriptGenerator.addReservedWords("event");
 Blockly.setLocale(eventMsg);
 Blockly.setLocale(cnpcMsg);
+Blockly.setLocale(cnpcMsgOverrides);
 
 // Register the blocks and generator with Blockly
 Blockly.common.defineBlocks(eventBlocks);
 Blockly.common.defineBlocks(cnpcBlocks);
+Blockly.common.defineBlocks(cnpcBlockOverrides);
 Object.assign(javascriptGenerator.forBlock, eventForBlocks);
 Object.assign(javascriptGenerator.forBlock, cnpcForBlocks);
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ editor: cnpc-blocks
 
 cnpc-blocks: cnpc-block-generator
 	dotnet ./Generator/bin/Release/net8.0/Generator.dll $(CNPC_API_DIR)
-	mkdir ./Editor/src/custom-npcs/
 	find . -maxdepth 1 -type f -name "*.g.js" -exec mv '{}' ./Editor/src/custom-npcs/ \;
 
 cnpc-block-generator:


### PR DESCRIPTION
## Description
The `block` field of `BlockEvent` is `IBlock`, while it can only be either `IBlockScripted` or `IBlockScriptedDoor`. This pull request overrides the block, adding a dropdown field to select which type to output.

## Consequences
- Closes #5